### PR TITLE
fix: video-controls-hide

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,7 @@
 .bottomVideo {
   width: 100%;
   object-fit: cover;
+  pointer-events: none;
 }
 
 .videoText {
@@ -28,13 +29,12 @@
   text-shadow: 1px 1px 0px rgba(0, 0, 0, 0.5);
   z-index: 2;
   text-align: center;
-  opacity: 0; 
+  opacity: 0;
   transition: opacity 1s ease-out;
 }
 
-
 .fadeIn {
-  opacity: 1; 
+  opacity: 1;
 }
 
 .background {
@@ -45,12 +45,20 @@
 @media (max-width: 768px) {
   .videoText {
     font-size: 20px;
-    line-height: 1.5; 
-  }
-   
-  .videoText span {
-    display: block; 
-    white-space: normal; 
+    line-height: 1.5;
   }
 
+  .videoText span {
+    display: block;
+    white-space: normal;
+  }
+}
+
+/* 비디오 컨트롤 숨기기 */
+.background-video::-webkit-media-controls {
+  display: none !important; /* Safari에서 컨트롤 숨기기 */
+}
+
+.background-video::media-controls {
+  display: none !important; /* Chrome에서 컨트롤 숨기기 */
 }

--- a/src/videoSection.js
+++ b/src/videoSection.js
@@ -47,6 +47,7 @@ const VideoSection = ({ videoSrc, text, scrollY, index }) => {
         autoPlay
         muted
         loop
+        playsInline // 모바일에서 전체화면 전환을 방지
       >
         <source src={videoSrc} type="video/mp4" />
       </video>


### PR DESCRIPTION
## 작업내용
- #11 
- 모바일 사파리에서 페이지 렌더링시 뒷 배경 비디오의 controls가 보이는 현상을 제거하기 위해
- playsInline을 추가
- 비디오 css에  pointer-events: none;를 추가했습니다.